### PR TITLE
feat: pass in whole module as arg to withWatcher

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,9 @@
       "@semantic-release/git",
       {
         "assets": [
-          "package.json"
+          "package.json",
+          "package-lock.json",
+          "CHANGELOG.md"
         ]
       }
     ]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can attach a watcher to the module by using the `withWatcher` method on the 
 
 > NOTE: this returns a copy of the old module, with the watcher attached instead of it being applied to the original module.
 
-`withWatcher` accepts a function with a single argument which is the `actions` object of the module and should return a generator function, which will run as the watcher.
+`withWatcher` accepts a function with a single argument which is the `module` created by `createModule` (with the exception of `withWatcher` method itself) and should return a generator function, which will run as the watcher.
 
 ```ts
 const counterModule = createModule({
@@ -102,11 +102,12 @@ const counterModule = createModule({
   selectors: {
     count: (state) => state.count,
   },
-}).withWatcher((actions) => {
+}).withWatcher(({ actions, selectors }) => {
   return function* watcher() {
     while (true) {
       yield take(actions.boom);
-      yield put(actions.increment(Math.floor(Math.random() * 10)));
+      const count = yield select(selectors.count);
+      yield put(actions.increment(Math.floor(Math.random() * count)));
     }
   };
 });
@@ -137,7 +138,7 @@ const explodeOnUnmountModule = createModule({
   selectors: {
     count: (state) => state.count,
   },
-}).withWatcher((actions) => {
+}).withWatcher(({ actions }) => {
   return function* watcher() {
     while (true) {
       yield take(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remodules",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remodules",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "7.16.7",

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -24,7 +24,7 @@ const testModule = createModule({
     value: (state) => state.value,
     valueTimes10: (state) => state.value * 10,
   },
-}).withWatcher((actions) => {
+}).withWatcher(({ actions }) => {
   return function* watcher() {
     while (true) {
       yield take(actions.boom.type);
@@ -76,7 +76,7 @@ const anotherTestModule = createModule({
     wind: (state) => state.wind,
     rain: (state) => state.rain,
   },
-}).withWatcher((actions) => {
+}).withWatcher(({ actions }) => {
   return function* watcher() {
     while (true) {
       yield take(actions.loadData.type);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import {
   type Slice,
   type SliceCaseReducers,
   type Store,
-  type CaseReducerActions,
 } from "@reduxjs/toolkit";
 import { type ThunkMiddlewareFor } from "@reduxjs/toolkit/dist/getDefaultMiddleware";
 import { useEffect, useRef, useState } from "react";
@@ -47,10 +46,9 @@ export type Module<
   CaseReducers extends SliceCaseReducers<State> = SliceCaseReducers<State>,
   Selectors extends SelectorsShape<State> = {},
   Name extends string = string,
-  ModuleSlice = Slice<State, CaseReducers, Name>
+  ModuleSlice = Slice<State, CaseReducers, Name> & { selectors: FinalSelectors<State, Name, Selectors>; }
   > = ModuleSlice & {
-    selectors: FinalSelectors<State, Name, Selectors>;
-    withWatcher<Watcher extends () => Generator>(createWatcher: (action: CaseReducerActions<CaseReducers>) => Watcher): ModuleWithWatcher<
+    withWatcher<Watcher extends () => Generator>(createWatcher: (action: ModuleSlice) => Watcher): ModuleWithWatcher<
       State,
       CaseReducers,
       Selectors,
@@ -91,9 +89,12 @@ export const createModule = <
     {} as FinalSelectors<State, Name, Selectors>
   );
 
+  const moduleSlice = { ...slice, selectors };
+
   return {
-    ...slice, selectors, withWatcher(createWatcher) {
-      const watcher = createWatcher(slice.actions);
+    ...moduleSlice,
+    withWatcher(createWatcher) {
+      const watcher = createWatcher(moduleSlice);
       return { ...this, watcher };
     }
   };


### PR DESCRIPTION
BREAKING CHANGE: withWatcher now accepts rest of the module
(excluding watcher of course) as argument

- **Please check if the PR fulfils these requirements**

* [x] The commit messages follow our [contribution guidelines](/CONTRIBUTING.md)
* [x] Your contributions follows out [Code of Conduct](/CODE_OF_CONDUCT.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Only `actions` object is passed to `withWatcher`.

- **What is the new behavior (if this is a feature change)?**

Whole module is passed into `withWatcher` as an argument.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes, see above

- **Other information**:
