### PR TITLE
fix: slice selectors can be optional

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -539,4 +539,14 @@ describe("redux dynamic modules", () => {
       );
     });
   });
+
+  it("createModule does not throw an error when selectors is not provided", () => {
+    expect(() =>
+      createModule({
+        name: "testModule",
+        initialState: {},
+        reducers: {},
+      })
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit messages follow our [contribution guidelines](/CONTRIBUTING.md)
* [x] Your contributions follows out [Code of Conduct](/CODE_OF_CONDUCT.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

When `selectors` is not defined `createModule` throws an error

- **What is the new behavior (if this is a feature change)?**

`selectors` can be `undefined` in `createModule`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

- **Other information**:
