### PR TITLE
Fix/select in saga top level

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -242,10 +242,10 @@ export const createDynamicStore = <
       return;
     }
     moduleCount.set(newModule, 1);
+    updateReducer();
     if (newModule.watcher) {
       addSaga(newModule.watcher);
     }
-    updateReducer();
     store.dispatch(moduleAdded(newModule.name) as any);
   };
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit messages follow our [contribution guidelines](/CONTRIBUTING.md)
* [x] Your contributions follows out [Code of Conduct](/CODE_OF_CONDUCT.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When using `yield select` in saga while in the same cycle as the one that mounts the module, the state is not yet accessible so selectors throw errors.

- **What is the new behavior (if this is a feature change)?**

Mount reducer before running saga.

By the time the saga runs, the state is already accessible.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking change

- **Other information**:

See new test for demonstration